### PR TITLE
fix: remove python version requirement from pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,3 @@ flake8 = "==6.1.0"
 isort = "==5.12.0"
 mypy = "==1.5.1"
 pandas-stubs = "==2.0.3.230814"
-
-[requires]
-python_version = "3.11"


### PR DESCRIPTION
We specify requirements in the documentation and the dockerfile, no need to do it in the pipfile.