### PR TITLE
Add default pylint compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ logger.setLevel(logging.INFO)
 
 
 def main(input_file: str) -> None:
-    """ main function """
+    """main function"""
     delete_cols = [
         "MBR_SUD",
         "ATTRIBUTED_PCP",

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+""" data-engineering-exercise main.py """
 import argparse
 import logging
 import os
@@ -15,6 +16,7 @@ logger.setLevel(logging.INFO)
 
 
 def main(input_file: str) -> None:
+    """ main function """
     delete_cols = [
         "MBR_SUD",
         "ATTRIBUTED_PCP",
@@ -25,26 +27,25 @@ def main(input_file: str) -> None:
     ]
 
     try:
-        df = pd.read_csv(input_file, dtype=str)
-    except FileNotFoundError as e:
-        logger.error(f"FileNotFoundError: {e}")
+        dataframe = pd.read_csv(input_file, dtype=str)
+    except FileNotFoundError as err_msg:
+        logger.error("FileNotFoundError: %s", err_msg)
         sys.exit(1)
 
     try:
         for col in delete_cols:
-            df = df.drop(columns=col)
-    except KeyError as e:
-        logger.warning(f"KeyError: Some columns failed to drop. Error: {e}")
-        pass
+            dataframe = dataframe.drop(columns=col)
+    except KeyError as err_msg:
+        logger.warning("KeyError: Some columns failed to drop. Error: %s", err_msg)
 
     try:
         output_file = os.path.splitext(input_file)[0] + "_out.csv"
-        df.to_csv(output_file, index=False)
-    except PermissionError as e:
-        logger.error(f"PermissionError: {e}")
+        dataframe.to_csv(output_file, index=False)
+    except PermissionError as err_msg:
+        logger.error("PermissionError: %s", err_msg)
         sys.exit(1)
 
-    logger.info(f"Output file: {output_file}")
+    logger.info("Output file: %s", output_file)
     logger.info("Done!")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 120
+
+[black]
+line-length = 120
+
+[isort]
+line_length = 120


### PR DESCRIPTION
This is to support ms-python.pylint compatibility to help interviewees be less confused when seeing linting squiggles.